### PR TITLE
Load scripts over the appropriate protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 
 <!--[if lt IE 9]>
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
   <script>window.attachEvent("onload", function() { CFInstall.check({ mode: "overlay" }); });</script>
 <![endif]-->
 
@@ -64,7 +64,7 @@
 <div id="graph"></div>
 <div id="wrapper"></div>
 
-<p class="fork"><a href="http://github.com/edds/browser-matrix">View on GitHub</a></p>
+<p class="fork"><a href="//github.com/edds/browser-matrix">View on GitHub</a></p>
 
 <div class="overlay">
   <p>
@@ -81,7 +81,7 @@
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 <!--[if gt IE 8]><!-->
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js"></script>
 <script src="javascripts/vendor/mustache.js"></script>
 
 <script src="javascripts/auth.js"></script>


### PR DESCRIPTION
GitHub pages now serves over HTTPS, and thus the old D3 script load was failing.
